### PR TITLE
Bootstrap: Use file dependencies to enable initial chart packaging

### DIFF
--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -15,14 +15,14 @@ appVersion: 3.0.5
 dependencies:
 - condition: redis.enabled
   name: redis
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 22.x.x
 - condition: postgresql.enabled
   name: postgresql
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 16.x.x
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/apache/Chart.yaml
+++ b/bitnami/apache/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 appVersion: 2.4.65
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/apisix/Chart.yaml
+++ b/bitnami/apisix/Chart.yaml
@@ -17,10 +17,10 @@ appVersion: 3.13.0
 dependencies:
 - condition: etcd.enabled
   name: etcd
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 12.x.x
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/appsmith/Chart.yaml
+++ b/bitnami/appsmith/Chart.yaml
@@ -17,14 +17,14 @@ appVersion: 1.85.0
 dependencies:
 - condition: redis.enabled
   name: redis
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 22.x.x
 - condition: mongodb.enabled
   name: mongodb
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 16.x.x
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/argo-cd/Chart.yaml
+++ b/bitnami/argo-cd/Chart.yaml
@@ -19,10 +19,10 @@ appVersion: 3.1.1
 dependencies:
 - condition: redis.enabled
   name: redis
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 22.x.x
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/argo-workflows/Chart.yaml
+++ b/bitnami/argo-workflows/Chart.yaml
@@ -17,14 +17,14 @@ appVersion: 3.7.1
 dependencies:
 - condition: postgresql.enabled
   name: postgresql
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 16.x.x
 - condition: mysql.enabled
   name: mysql
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 14.x.x
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/aspnet-core/Chart.yaml
+++ b/bitnami/aspnet-core/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 appVersion: 9.0.8
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/cadvisor/Chart.yaml
+++ b/bitnami/cadvisor/Chart.yaml
@@ -12,7 +12,7 @@ apiVersion: v2
 appVersion: 0.53.0
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/cassandra/Chart.yaml
+++ b/bitnami/cassandra/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 appVersion: 5.0.5
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/cert-manager/Chart.yaml
+++ b/bitnami/cert-manager/Chart.yaml
@@ -18,7 +18,7 @@ apiVersion: v2
 appVersion: 1.18.2
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/chainloop/Chart.yaml
+++ b/bitnami/chainloop/Chart.yaml
@@ -18,17 +18,17 @@ apiVersion: v2
 appVersion: 1.43.0
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x
 - condition: postgresql.enabled
   name: postgresql
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 16.x.x
 - condition: development
   name: vault
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 1.x.x
 description: Chainloop is an open-source Software Supply Chain control plane, a single
   source of truth for metadata and artifacts, plus a declarative attestation process.

--- a/bitnami/cilium/Chart.yaml
+++ b/bitnami/cilium/Chart.yaml
@@ -23,12 +23,12 @@ appVersion: 1.18.1
 dependencies:
 - condition: etcd.enabled
   name: etcd
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - cilium-database
   version: 12.x.x
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/clickhouse-operator/Chart.yaml
+++ b/bitnami/clickhouse-operator/Chart.yaml
@@ -17,7 +17,7 @@ apiVersion: v2
 appVersion: 0.25.3
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/clickhouse/Chart.yaml
+++ b/bitnami/clickhouse/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 appVersion: 25.7.4
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/cloudnative-pg/Chart.yaml
+++ b/bitnami/cloudnative-pg/Chart.yaml
@@ -18,7 +18,7 @@ apiVersion: v2
 appVersion: 1.26.1
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/concourse/Chart.yaml
+++ b/bitnami/concourse/Chart.yaml
@@ -15,10 +15,10 @@ appVersion: 7.13.2
 dependencies:
 - condition: postgresql.enabled
   name: postgresql
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 16.X.X
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/consul/Chart.yaml
+++ b/bitnami/consul/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 appVersion: 1.21.4
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/contour/Chart.yaml
+++ b/bitnami/contour/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 appVersion: 1.32.1
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/deepspeed/Chart.yaml
+++ b/bitnami/deepspeed/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 appVersion: 0.17.5
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/discourse/Chart.yaml
+++ b/bitnami/discourse/Chart.yaml
@@ -15,14 +15,14 @@ appVersion: 3.5.0
 dependencies:
 - condition: redis.enabled
   name: redis
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 22.X.X
 - condition: postgresql.enabled
   name: postgresql
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 16.X.X
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/dremio/Chart.yaml
+++ b/bitnami/dremio/Chart.yaml
@@ -17,14 +17,14 @@ appVersion: 26.0.0
 dependencies:
 - condition: minio.enabled
   name: minio
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 17.x.x
 - condition: zookeeper.enabled
   name: zookeeper
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 13.x.x
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/drupal/Chart.yaml
+++ b/bitnami/drupal/Chart.yaml
@@ -17,10 +17,10 @@ appVersion: 11.2.3
 dependencies:
 - condition: mariadb.enabled
   name: mariadb
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 22.x.x
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/ejbca/Chart.yaml
+++ b/bitnami/ejbca/Chart.yaml
@@ -13,12 +13,12 @@ appVersion: 9.1.1
 dependencies:
 - condition: mariadb.enabled
   name: mariadb
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - ejbca-database
   version: 22.x.x
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -17,10 +17,10 @@ appVersion: 9.1.2
 dependencies:
 - condition: global.kibanaEnabled
   name: kibana
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 12.x.x
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/envoy-gateway/Chart.yaml
+++ b/bitnami/envoy-gateway/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 appVersion: 1.5.0
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -14,7 +14,7 @@ apiVersion: v2
 appVersion: 3.6.4
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/external-dns/Chart.yaml
+++ b/bitnami/external-dns/Chart.yaml
@@ -12,7 +12,7 @@ apiVersion: v2
 appVersion: 0.18.0
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/flink/Chart.yaml
+++ b/bitnami/flink/Chart.yaml
@@ -12,7 +12,7 @@ apiVersion: v2
 appVersion: 2.1.0
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/fluent-bit/Chart.yaml
+++ b/bitnami/fluent-bit/Chart.yaml
@@ -12,7 +12,7 @@ apiVersion: v2
 appVersion: 4.0.8
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/fluentd/Chart.yaml
+++ b/bitnami/fluentd/Chart.yaml
@@ -12,7 +12,7 @@ apiVersion: v2
 appVersion: 1.19.0
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/flux/Chart.yaml
+++ b/bitnami/flux/Chart.yaml
@@ -24,7 +24,7 @@ apiVersion: v2
 appVersion: 1.6.2
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/ghost/Chart.yaml
+++ b/bitnami/ghost/Chart.yaml
@@ -15,12 +15,12 @@ appVersion: 6.0.5
 dependencies:
 - condition: mysql.enabled
   name: mysql
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - ghost-database
   version: 14.x.x
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/gitea/Chart.yaml
+++ b/bitnami/gitea/Chart.yaml
@@ -15,10 +15,10 @@ appVersion: 1.24.5
 dependencies:
 - condition: postgresql.enabled
   name: postgresql
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 16.x.x
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/gitlab-runner/Chart.yaml
+++ b/bitnami/gitlab-runner/Chart.yaml
@@ -14,7 +14,7 @@ apiVersion: v2
 appVersion: 18.3.0
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/grafana-alloy/Chart.yaml
+++ b/bitnami/grafana-alloy/Chart.yaml
@@ -13,7 +13,7 @@ apiVersion: v2
 appVersion: 1.10.2
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/grafana-k6-operator/Chart.yaml
+++ b/bitnami/grafana-k6-operator/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 appVersion: 0.0.23
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/grafana-loki/Chart.yaml
+++ b/bitnami/grafana-loki/Chart.yaml
@@ -18,30 +18,30 @@ dependencies:
 - alias: grafanaalloy
   condition: grafanaalloy.enabled
   name: grafana-alloy
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 1.x.x
 - alias: memcachedchunks
   condition: memcachedchunks.enabled
   name: memcached
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 7.x.x
 - alias: memcachedfrontend
   condition: memcachedfrontend.enabled
   name: memcached
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 7.x.x
 - alias: memcachedindexqueries
   condition: memcachedindexqueries.enabled
   name: memcached
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 7.x.x
 - alias: memcachedindexwrites
   condition: memcachedindexwrites.enabled
   name: memcached
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 7.x.x
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/grafana-mimir/Chart.yaml
+++ b/bitnami/grafana-mimir/Chart.yaml
@@ -19,30 +19,30 @@ appVersion: 2.17.0
 dependencies:
 - condition: minio.enabled
   name: minio
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 17.x.x
 - alias: memcachedmetadata
   condition: memcachedmetadata.enabled
   name: memcached
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 7.x.x
 - alias: memcachedindex
   condition: memcachedindex.enabled
   name: memcached
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 7.x.x
 - alias: memcachedfrontend
   condition: memcachedfrontend.enabled
   name: memcached
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 7.x.x
 - alias: memcachedchunks
   condition: memcachedchunks.enabled
   name: memcached
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 7.x.x
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/grafana-operator/Chart.yaml
+++ b/bitnami/grafana-operator/Chart.yaml
@@ -14,7 +14,7 @@ apiVersion: v2
 appVersion: 5.19.4
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/grafana-tempo/Chart.yaml
+++ b/bitnami/grafana-tempo/Chart.yaml
@@ -19,10 +19,10 @@ appVersion: 2.8.2
 dependencies:
 - condition: memcached.enabled
   name: memcached
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 7.x.x
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/grafana/Chart.yaml
+++ b/bitnami/grafana/Chart.yaml
@@ -14,7 +14,7 @@ apiVersion: v2
 appVersion: 12.1.1
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/haproxy/Chart.yaml
+++ b/bitnami/haproxy/Chart.yaml
@@ -12,7 +12,7 @@ apiVersion: v2
 appVersion: 3.2.4
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -29,14 +29,14 @@ appVersion: 2.13.2
 dependencies:
 - condition: redis.enabled
   name: redis
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 22.x.x
 - condition: postgresql.enabled
   name: postgresql
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 16.x.x
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/influxdb/Chart.yaml
+++ b/bitnami/influxdb/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 appVersion: 3.3.0
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/jaeger/Chart.yaml
+++ b/bitnami/jaeger/Chart.yaml
@@ -14,13 +14,13 @@ apiVersion: v2
 appVersion: 2.9.0
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x
 - condition: cassandra.enabled
   name: cassandra
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 12.x.x
 description: Jaeger is a distributed tracing system. It is used for monitoring and
   troubleshooting microservices-based distributed systems.

--- a/bitnami/janusgraph/Chart.yaml
+++ b/bitnami/janusgraph/Chart.yaml
@@ -17,10 +17,10 @@ appVersion: 1.1.0
 dependencies:
 - condition: storageBackend.cassandra.enabled
   name: cassandra
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 12.x.x
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/jenkins/Chart.yaml
+++ b/bitnami/jenkins/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 appVersion: 2.516.2
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/jupyterhub/Chart.yaml
+++ b/bitnami/jupyterhub/Chart.yaml
@@ -19,10 +19,10 @@ appVersion: 5.3.0
 dependencies:
 - condition: postgresql.enabled
   name: postgresql
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 16.x.x
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -18,7 +18,7 @@ apiVersion: v2
 appVersion: 4.0.0
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -15,10 +15,10 @@ appVersion: 26.3.3
 dependencies:
 - condition: postgresql.enabled
   name: postgresql
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 16.x.x
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/keydb/Chart.yaml
+++ b/bitnami/keydb/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 appVersion: 6.3.4
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/kiam/Chart.yaml
+++ b/bitnami/kiam/Chart.yaml
@@ -12,7 +12,7 @@ apiVersion: v2
 appVersion: 4.2.0
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/kibana/Chart.yaml
+++ b/bitnami/kibana/Chart.yaml
@@ -14,7 +14,7 @@ apiVersion: v2
 appVersion: 9.1.2
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/kong/Chart.yaml
+++ b/bitnami/kong/Chart.yaml
@@ -15,16 +15,16 @@ appVersion: 3.9.1
 dependencies:
 - condition: postgresql.enabled
   name: postgresql
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 16.x.x
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x
 - condition: cassandra.enabled
   name: cassandra
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 12.x.x
 description: Kong is an open source Microservice API gateway and platform designed
   for managing microservices requests of high-availability, fault-tolerance, and distributed

--- a/bitnami/kube-arangodb/Chart.yaml
+++ b/bitnami/kube-arangodb/Chart.yaml
@@ -14,7 +14,7 @@ apiVersion: v2
 appVersion: 1.3.0
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/kube-prometheus/Chart.yaml
+++ b/bitnami/kube-prometheus/Chart.yaml
@@ -21,14 +21,14 @@ appVersion: 0.85.0
 dependencies:
 - condition: exporters.enabled,exporters.node-exporter.enabled
   name: node-exporter
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 4.x.x
 - condition: exporters.enabled,exporters.kube-state-metrics.enabled
   name: kube-state-metrics
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 5.x.x
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/kube-state-metrics/Chart.yaml
+++ b/bitnami/kube-state-metrics/Chart.yaml
@@ -12,7 +12,7 @@ apiVersion: v2
 appVersion: 2.16.0
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/kuberay/Chart.yaml
+++ b/bitnami/kuberay/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 appVersion: 1.4.2
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/kubernetes-event-exporter/Chart.yaml
+++ b/bitnami/kubernetes-event-exporter/Chart.yaml
@@ -12,7 +12,7 @@ apiVersion: v2
 appVersion: 1.7.0
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/logstash/Chart.yaml
+++ b/bitnami/logstash/Chart.yaml
@@ -14,7 +14,7 @@ apiVersion: v2
 appVersion: 9.1.2
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/mariadb-galera/Chart.yaml
+++ b/bitnami/mariadb-galera/Chart.yaml
@@ -14,7 +14,7 @@ apiVersion: v2
 appVersion: 12.0.2
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/mariadb/Chart.yaml
+++ b/bitnami/mariadb/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 appVersion: 12.0.2
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/mastodon/Chart.yaml
+++ b/bitnami/mastodon/Chart.yaml
@@ -15,26 +15,26 @@ appVersion: 4.4.3
 dependencies:
 - condition: redis.enabled
   name: redis
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 22.x.x
 - condition: postgresql.enabled
   name: postgresql
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 16.x.x
 - condition: elasticsearch.enabled
   name: elasticsearch
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 22.x.x
 - condition: minio.enabled
   name: minio
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 17.x.x
 - condition: apache.enabled
   name: apache
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 11.x.x
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/matomo/Chart.yaml
+++ b/bitnami/matomo/Chart.yaml
@@ -17,10 +17,10 @@ appVersion: 5.3.2
 dependencies:
 - condition: mariadb.enabled
   name: mariadb
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 22.x.x
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/memcached/Chart.yaml
+++ b/bitnami/memcached/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 appVersion: 1.6.39
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/metallb/Chart.yaml
+++ b/bitnami/metallb/Chart.yaml
@@ -14,7 +14,7 @@ apiVersion: v2
 appVersion: 0.15.2
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/metrics-server/Chart.yaml
+++ b/bitnami/metrics-server/Chart.yaml
@@ -12,7 +12,7 @@ apiVersion: v2
 appVersion: 0.8.0
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/milvus/Chart.yaml
+++ b/bitnami/milvus/Chart.yaml
@@ -19,18 +19,18 @@ appVersion: 2.6.0
 dependencies:
 - condition: etcd.enabled
   name: etcd
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 12.x.x
 - condition: kafka.enabled
   name: kafka
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 32.x.x
 - condition: minio.enabled
   name: minio
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 17.x.x
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/minio-operator/Chart.yaml
+++ b/bitnami/minio-operator/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 appVersion: 7.1.1
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/minio/Chart.yaml
+++ b/bitnami/minio/Chart.yaml
@@ -18,7 +18,7 @@ apiVersion: v2
 appVersion: 2025.7.23
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/mlflow/Chart.yaml
+++ b/bitnami/mlflow/Chart.yaml
@@ -17,14 +17,14 @@ appVersion: 3.3.1
 dependencies:
 - condition: minio.enabled
   name: minio
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 17.x.x
 - condition: postgresql.enabled
   name: postgresql
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 16.x.x
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/mongodb-sharded/Chart.yaml
+++ b/bitnami/mongodb-sharded/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 appVersion: 8.0.13
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -20,7 +20,7 @@ apiVersion: v2
 appVersion: 8.0.13
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/moodle/Chart.yaml
+++ b/bitnami/moodle/Chart.yaml
@@ -17,10 +17,10 @@ appVersion: 5.0.2
 dependencies:
 - condition: mariadb.enabled
   name: mariadb
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 22.x.x
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/multus-cni/Chart.yaml
+++ b/bitnami/multus-cni/Chart.yaml
@@ -12,7 +12,7 @@ apiVersion: v2
 appVersion: 4.2.2
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 appVersion: 9.4.0
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/nats/Chart.yaml
+++ b/bitnami/nats/Chart.yaml
@@ -14,7 +14,7 @@ apiVersion: v2
 appVersion: 2.11.8
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/neo4j/Chart.yaml
+++ b/bitnami/neo4j/Chart.yaml
@@ -14,7 +14,7 @@ apiVersion: v2
 appVersion: 5.26.10
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/nessie/Chart.yaml
+++ b/bitnami/nessie/Chart.yaml
@@ -17,10 +17,10 @@ appVersion: 0.104.9
 dependencies:
 - condition: postgresql.enabled
   name: postgresql
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 16.x.x
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/nginx-ingress-controller/Chart.yaml
+++ b/bitnami/nginx-ingress-controller/Chart.yaml
@@ -14,7 +14,7 @@ apiVersion: v2
 appVersion: 1.13.1
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 appVersion: 1.29.1
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/node-exporter/Chart.yaml
+++ b/bitnami/node-exporter/Chart.yaml
@@ -12,7 +12,7 @@ apiVersion: v2
 appVersion: 1.9.1
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/oauth2-proxy/Chart.yaml
+++ b/bitnami/oauth2-proxy/Chart.yaml
@@ -13,10 +13,10 @@ appVersion: 7.12.0
 dependencies:
 - condition: redis.enabled
   name: redis
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 22.x.x
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/odoo/Chart.yaml
+++ b/bitnami/odoo/Chart.yaml
@@ -13,10 +13,10 @@ appVersion: 18.0.20250805
 dependencies:
 - condition: postgresql.enabled
   name: postgresql
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 16.x.x
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/opensearch/Chart.yaml
+++ b/bitnami/opensearch/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 appVersion: 3.2.0
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/parse/Chart.yaml
+++ b/bitnami/parse/Chart.yaml
@@ -16,10 +16,10 @@ apiVersion: v2
 appVersion: 8.2.3
 dependencies:
 - name: mongodb
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 16.x.x
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/phpmyadmin/Chart.yaml
+++ b/bitnami/phpmyadmin/Chart.yaml
@@ -15,12 +15,12 @@ appVersion: 5.2.2
 dependencies:
 - condition: db.bundleTestDB
   name: mariadb
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - phpmyadmin-database
   version: 22.x.x
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/pinniped/Chart.yaml
+++ b/bitnami/pinniped/Chart.yaml
@@ -12,7 +12,7 @@ apiVersion: v2
 appVersion: 0.40.0
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -18,7 +18,7 @@ apiVersion: v2
 appVersion: 17.6.0
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 appVersion: 17.6.0
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/prometheus/Chart.yaml
+++ b/bitnami/prometheus/Chart.yaml
@@ -18,7 +18,7 @@ apiVersion: v2
 appVersion: 3.5.0
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/pytorch/Chart.yaml
+++ b/bitnami/pytorch/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 appVersion: 2.8.0
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/rabbitmq-cluster-operator/Chart.yaml
+++ b/bitnami/rabbitmq-cluster-operator/Chart.yaml
@@ -18,7 +18,7 @@ apiVersion: v2
 appVersion: 2.16.1
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -14,7 +14,7 @@ apiVersion: v2
 appVersion: 4.1.3
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/redis-cluster/Chart.yaml
+++ b/bitnami/redis-cluster/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 appVersion: 8.2.1
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -20,7 +20,7 @@ apiVersion: v2
 appVersion: 8.2.1
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/redmine/Chart.yaml
+++ b/bitnami/redmine/Chart.yaml
@@ -15,14 +15,14 @@ appVersion: 6.0.6
 dependencies:
 - condition: postgresql.enabled
   name: postgresql
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 16.x.x
 - condition: mariadb.enabled
   name: mariadb
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 22.x.x
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/schema-registry/Chart.yaml
+++ b/bitnami/schema-registry/Chart.yaml
@@ -13,10 +13,10 @@ appVersion: 8.0.0
 dependencies:
 - condition: kafka.enabled
   name: kafka
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 32.x.x
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/scylladb/Chart.yaml
+++ b/bitnami/scylladb/Chart.yaml
@@ -14,7 +14,7 @@ apiVersion: v2
 appVersion: 2025.2.2
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/sealed-secrets/Chart.yaml
+++ b/bitnami/sealed-secrets/Chart.yaml
@@ -12,7 +12,7 @@ apiVersion: v2
 appVersion: 0.31.0
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/seaweedfs/Chart.yaml
+++ b/bitnami/seaweedfs/Chart.yaml
@@ -19,18 +19,18 @@ appVersion: 3.96.0
 dependencies:
 - condition: mariadb.enabled
   name: mariadb
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - seaweedfs-database
   version: 22.x.x
 - condition: postgresql.enabled
   name: postgresql
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - seaweedfs-database
   version: 16.x.x
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/solr/Chart.yaml
+++ b/bitnami/solr/Chart.yaml
@@ -15,10 +15,10 @@ appVersion: 9.9.0
 dependencies:
 - condition: zookeeper.enabled
   name: zookeeper
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 13.x.x
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/sonarqube/Chart.yaml
+++ b/bitnami/sonarqube/Chart.yaml
@@ -17,10 +17,10 @@ appVersion: 25.8.0
 dependencies:
 - condition: postgresql.enabled
   name: postgresql
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 16.x.x
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/spark/Chart.yaml
+++ b/bitnami/spark/Chart.yaml
@@ -12,7 +12,7 @@ apiVersion: v2
 appVersion: 4.0.0
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/superset/Chart.yaml
+++ b/bitnami/superset/Chart.yaml
@@ -13,14 +13,14 @@ appVersion: 5.0.0
 dependencies:
 - condition: redis.enabled
   name: redis
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 22.x.x
 - condition: postgresql.enabled
   name: postgresql
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 16.x.x
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/tensorflow-resnet/Chart.yaml
+++ b/bitnami/tensorflow-resnet/Chart.yaml
@@ -14,7 +14,7 @@ apiVersion: v2
 appVersion: 2.19.1
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -15,10 +15,10 @@ appVersion: 0.39.2
 dependencies:
 - condition: minio.enabled
   name: minio
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 17.x.x
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/tomcat/Chart.yaml
+++ b/bitnami/tomcat/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 appVersion: 11.0.10
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/valkey-cluster/Chart.yaml
+++ b/bitnami/valkey-cluster/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 appVersion: 8.1.3
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/valkey/Chart.yaml
+++ b/bitnami/valkey/Chart.yaml
@@ -20,7 +20,7 @@ apiVersion: v2
 appVersion: 8.1.3
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/vault/Chart.yaml
+++ b/bitnami/vault/Chart.yaml
@@ -18,7 +18,7 @@ apiVersion: v2
 appVersion: 1.20.2
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/victoriametrics/Chart.yaml
+++ b/bitnami/victoriametrics/Chart.yaml
@@ -23,7 +23,7 @@ apiVersion: v2
 appVersion: 1.124.0
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/whereabouts/Chart.yaml
+++ b/bitnami/whereabouts/Chart.yaml
@@ -12,7 +12,7 @@ apiVersion: v2
 appVersion: 0.9.2
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/wildfly/Chart.yaml
+++ b/bitnami/wildfly/Chart.yaml
@@ -14,7 +14,7 @@ apiVersion: v2
 appVersion: 37.0.0
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/wordpress/Chart.yaml
+++ b/bitnami/wordpress/Chart.yaml
@@ -17,14 +17,14 @@ appVersion: 6.8.2
 dependencies:
 - condition: memcached.enabled
   name: memcached
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 7.x.x
 - condition: mariadb.enabled
   name: mariadb
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 22.x.x
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/zipkin/Chart.yaml
+++ b/bitnami/zipkin/Chart.yaml
@@ -15,10 +15,10 @@ appVersion: 3.5.1
 dependencies:
 - condition: cassandra.enabled
   name: cassandra
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   version: 12.x.x
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x

--- a/bitnami/zookeeper/Chart.yaml
+++ b/bitnami/zookeeper/Chart.yaml
@@ -14,7 +14,7 @@ apiVersion: v2
 appVersion: 3.9.3
 dependencies:
 - name: common
-  repository: https://portswigger-cloud.github.io/legacy-charts/
+  repository: file://..
   tags:
   - bitnami-common
   version: 2.x.x


### PR DESCRIPTION
This is a temporary change to bootstrap the Helm repository:
- Changed all repository references from GitHub Pages URL to 'file://..'
- This allows chart-releaser-action to package charts without needing existing index
- After initial release, we'll switch back to GitHub Pages URLs

Addresses: Chart dependencies need to reference charts that don't exist yet