### PR TITLE
Increment chart versions for dependency constraint changes

### DIFF
--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -14,11 +14,11 @@ dependencies:
 - condition: redis.enabled
   name: redis
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 8.x.x
+  version: 22.0.6-legacy
 - condition: postgresql.enabled
   name: postgresql
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 17.x.x
+  version: 16.7.27-legacy
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -40,4 +40,4 @@ maintainers:
 name: airflow
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/airflow
-version: 25.0.2-legacy
+version: 25.0.3-legacy

--- a/bitnami/apisix/Chart.yaml
+++ b/bitnami/apisix/Chart.yaml
@@ -15,7 +15,7 @@ dependencies:
 - condition: etcd.enabled
   name: etcd
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 3.x.x
+  version: 12.0.18-legacy
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -41,4 +41,4 @@ maintainers:
 name: apisix
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/apisix
-version: 6.0.0-legacy
+version: 6.0.1-legacy

--- a/bitnami/appsmith/Chart.yaml
+++ b/bitnami/appsmith/Chart.yaml
@@ -15,11 +15,11 @@ dependencies:
 - condition: redis.enabled
   name: redis
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 8.x.x
+  version: 22.0.6-legacy
 - condition: mongodb.enabled
   name: mongodb
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 8.x.x
+  version: 16.5.45-legacy
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -38,4 +38,4 @@ maintainers:
 name: appsmith
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/appsmith
-version: 7.0.3-legacy
+version: 7.0.4-legacy

--- a/bitnami/argo-cd/Chart.yaml
+++ b/bitnami/argo-cd/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
 - condition: redis.enabled
   name: redis
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 8.x.x
+  version: 22.0.6-legacy
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -36,4 +36,4 @@ maintainers:
 name: argo-cd
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/argo-cd
-version: 11.0.0-legacy
+version: 11.0.1-legacy

--- a/bitnami/argo-workflows/Chart.yaml
+++ b/bitnami/argo-workflows/Chart.yaml
@@ -15,11 +15,11 @@ dependencies:
 - condition: postgresql.enabled
   name: postgresql
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 17.x.x
+  version: 16.7.27-legacy
 - condition: mysql.enabled
   name: mysql
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 9.x.x
+  version: 14.0.3-legacy
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -41,4 +41,4 @@ maintainers:
 name: argo-workflows
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/argo-workflows
-version: 13.0.6-legacy
+version: 13.0.7-legacy

--- a/bitnami/chainloop/Chart.yaml
+++ b/bitnami/chainloop/Chart.yaml
@@ -21,7 +21,7 @@ dependencies:
 - condition: postgresql.enabled
   name: postgresql
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 17.x.x
+  version: 16.7.27-legacy
 - condition: development
   name: vault
   repository: https://portswigger-cloud.github.io/legacy-charts/
@@ -57,4 +57,4 @@ maintainers:
 name: chainloop
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/chainloop
-version: 4.0.74-legacy
+version: 4.0.75-legacy

--- a/bitnami/cilium/Chart.yaml
+++ b/bitnami/cilium/Chart.yaml
@@ -20,7 +20,7 @@ dependencies:
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
   - cilium-database
-  version: 3.x.x
+  version: 12.0.18-legacy
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -42,4 +42,4 @@ maintainers:
 name: cilium
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/cilium
-version: 3.1.9-legacy
+version: 3.1.10-legacy

--- a/bitnami/concourse/Chart.yaml
+++ b/bitnami/concourse/Chart.yaml
@@ -14,7 +14,7 @@ dependencies:
 - condition: postgresql.enabled
   name: postgresql
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 17.x.x
+  version: 16.7.27-legacy
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -38,4 +38,4 @@ maintainers:
 name: concourse
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/concourse
-version: 5.1.45-legacy
+version: 5.1.46-legacy

--- a/bitnami/discourse/Chart.yaml
+++ b/bitnami/discourse/Chart.yaml
@@ -14,11 +14,11 @@ dependencies:
 - condition: redis.enabled
   name: redis
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 8.x.x
+  version: 22.0.6-legacy
 - condition: postgresql.enabled
   name: postgresql
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 17.x.x
+  version: 16.7.27-legacy
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -38,4 +38,4 @@ maintainers:
 name: discourse
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/discourse
-version: 17.0.1-legacy
+version: 17.0.2-legacy

--- a/bitnami/dremio/Chart.yaml
+++ b/bitnami/dremio/Chart.yaml
@@ -15,7 +15,7 @@ dependencies:
 - condition: minio.enabled
   name: minio
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 2025.x.x
+  version: 17.0.21-legacy
 - condition: zookeeper.enabled
   name: zookeeper
   repository: https://portswigger-cloud.github.io/legacy-charts/
@@ -38,4 +38,4 @@ maintainers:
 name: dremio
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/dremio
-version: 3.0.13-legacy
+version: 3.0.14-legacy

--- a/bitnami/drupal/Chart.yaml
+++ b/bitnami/drupal/Chart.yaml
@@ -15,7 +15,7 @@ dependencies:
 - condition: mariadb.enabled
   name: mariadb
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 12.x.x
+  version: 22.0.0-legacy
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -40,4 +40,4 @@ maintainers:
 name: drupal
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/drupal
-version: 23.0.0-legacy
+version: 23.0.1-legacy

--- a/bitnami/ejbca/Chart.yaml
+++ b/bitnami/ejbca/Chart.yaml
@@ -15,7 +15,7 @@ dependencies:
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
   - ejbca-database
-  version: 12.x.x
+  version: 22.0.0-legacy
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -36,4 +36,4 @@ maintainers:
 name: ejbca
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/ejbca
-version: 19.0.0-legacy
+version: 19.0.1-legacy

--- a/bitnami/ghost/Chart.yaml
+++ b/bitnami/ghost/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
   - ghost-database
-  version: 9.x.x
+  version: 14.0.3-legacy
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -41,4 +41,4 @@ maintainers:
 name: ghost
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/ghost
-version: 25.0.4-legacy
+version: 25.0.5-legacy

--- a/bitnami/gitea/Chart.yaml
+++ b/bitnami/gitea/Chart.yaml
@@ -14,7 +14,7 @@ dependencies:
 - condition: postgresql.enabled
   name: postgresql
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 17.x.x
+  version: 16.7.27-legacy
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -37,4 +37,4 @@ maintainers:
 name: gitea
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/gitea
-version: 3.2.22-legacy
+version: 3.2.23-legacy

--- a/bitnami/grafana-loki/Chart.yaml
+++ b/bitnami/grafana-loki/Chart.yaml
@@ -21,22 +21,22 @@ dependencies:
   condition: memcachedchunks.enabled
   name: memcached
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 1.x.x
+  version: 7.9.7-legacy
 - alias: memcachedfrontend
   condition: memcachedfrontend.enabled
   name: memcached
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 1.x.x
+  version: 7.9.7-legacy
 - alias: memcachedindexqueries
   condition: memcachedindexqueries.enabled
   name: memcached
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 1.x.x
+  version: 7.9.7-legacy
 - alias: memcachedindexwrites
   condition: memcachedindexwrites.enabled
   name: memcached
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 1.x.x
+  version: 7.9.7-legacy
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -58,4 +58,4 @@ maintainers:
 name: grafana-loki
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/grafana-loki
-version: 6.0.6-legacy
+version: 6.0.7-legacy

--- a/bitnami/grafana-mimir/Chart.yaml
+++ b/bitnami/grafana-mimir/Chart.yaml
@@ -16,27 +16,27 @@ dependencies:
 - condition: minio.enabled
   name: minio
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 2025.x.x
+  version: 17.0.21-legacy
 - alias: memcachedmetadata
   condition: memcachedmetadata.enabled
   name: memcached
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 1.x.x
+  version: 7.9.7-legacy
 - alias: memcachedindex
   condition: memcachedindex.enabled
   name: memcached
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 1.x.x
+  version: 7.9.7-legacy
 - alias: memcachedfrontend
   condition: memcachedfrontend.enabled
   name: memcached
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 1.x.x
+  version: 7.9.7-legacy
 - alias: memcachedchunks
   condition: memcachedchunks.enabled
   name: memcached
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 1.x.x
+  version: 7.9.7-legacy
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -57,4 +57,4 @@ maintainers:
 name: grafana-mimir
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/grafana-mimir
-version: 3.0.18-legacy
+version: 3.0.19-legacy

--- a/bitnami/grafana-tempo/Chart.yaml
+++ b/bitnami/grafana-tempo/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
 - condition: memcached.enabled
   name: memcached
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 1.x.x
+  version: 7.9.7-legacy
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -38,4 +38,4 @@ maintainers:
 name: grafana-tempo
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/grafana-tempo
-version: 4.0.17-legacy
+version: 4.0.18-legacy

--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -21,11 +21,11 @@ dependencies:
 - condition: redis.enabled
   name: redis
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 8.x.x
+  version: 22.0.6-legacy
 - condition: postgresql.enabled
   name: postgresql
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 17.x.x
+  version: 16.7.27-legacy
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -47,4 +47,4 @@ maintainers:
 name: harbor
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/harbor
-version: 27.0.3-legacy
+version: 27.0.4-legacy

--- a/bitnami/jaeger/Chart.yaml
+++ b/bitnami/jaeger/Chart.yaml
@@ -19,7 +19,7 @@ dependencies:
 - condition: cassandra.enabled
   name: cassandra
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 5.x.x
+  version: 12.3.11-legacy
 description: Jaeger is a distributed tracing system. It is used for monitoring and
   troubleshooting microservices-based distributed systems.
 home: https://bitnami.com
@@ -34,4 +34,4 @@ maintainers:
 name: jaeger
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/jaeger
-version: 6.0.5-legacy
+version: 6.0.6-legacy

--- a/bitnami/janusgraph/Chart.yaml
+++ b/bitnami/janusgraph/Chart.yaml
@@ -15,7 +15,7 @@ dependencies:
 - condition: storageBackend.cassandra.enabled
   name: cassandra
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 5.x.x
+  version: 12.3.11-legacy
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -36,4 +36,4 @@ maintainers:
 name: janusgraph
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/janusgraph
-version: 1.4.10-legacy
+version: 1.4.11-legacy

--- a/bitnami/jupyterhub/Chart.yaml
+++ b/bitnami/jupyterhub/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
 - condition: postgresql.enabled
   name: postgresql
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 17.x.x
+  version: 16.7.27-legacy
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -36,4 +36,4 @@ maintainers:
 name: jupyterhub
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/jupyterhub
-version: 10.0.5-legacy
+version: 10.0.6-legacy

--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -14,7 +14,7 @@ dependencies:
 - condition: postgresql.enabled
   name: postgresql
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 17.x.x
+  version: 16.7.27-legacy
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -34,4 +34,4 @@ maintainers:
 name: keycloak
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/keycloak
-version: 25.2.0-legacy
+version: 25.2.1-legacy

--- a/bitnami/kong/Chart.yaml
+++ b/bitnami/kong/Chart.yaml
@@ -14,7 +14,7 @@ dependencies:
 - condition: postgresql.enabled
   name: postgresql
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 17.x.x
+  version: 16.7.27-legacy
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -23,7 +23,7 @@ dependencies:
 - condition: cassandra.enabled
   name: cassandra
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 5.x.x
+  version: 12.3.11-legacy
 description: Kong is an open source Microservice API gateway and platform designed
   for managing microservices requests of high-availability, fault-tolerance, and distributed
   systems.
@@ -44,4 +44,4 @@ maintainers:
 name: kong
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kong
-version: 15.4.21-legacy
+version: 15.4.22-legacy

--- a/bitnami/mastodon/Chart.yaml
+++ b/bitnami/mastodon/Chart.yaml
@@ -14,23 +14,23 @@ dependencies:
 - condition: redis.enabled
   name: redis
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 8.x.x
+  version: 22.0.6-legacy
 - condition: postgresql.enabled
   name: postgresql
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 17.x.x
+  version: 16.7.27-legacy
 - condition: elasticsearch.enabled
   name: elasticsearch
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 9.x.x
+  version: 22.1.6-legacy
 - condition: minio.enabled
   name: minio
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 2025.x.x
+  version: 17.0.21-legacy
 - condition: apache.enabled
   name: apache
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 2.x.x
+  version: 11.4.29-legacy
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -49,4 +49,4 @@ maintainers:
 name: mastodon
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mastodon
-version: 14.0.0-legacy
+version: 14.0.1-legacy

--- a/bitnami/matomo/Chart.yaml
+++ b/bitnami/matomo/Chart.yaml
@@ -15,7 +15,7 @@ dependencies:
 - condition: mariadb.enabled
   name: mariadb
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 12.x.x
+  version: 22.0.0-legacy
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -38,4 +38,4 @@ maintainers:
 name: matomo
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/matomo
-version: 11.0.0-legacy
+version: 11.0.1-legacy

--- a/bitnami/milvus/Chart.yaml
+++ b/bitnami/milvus/Chart.yaml
@@ -16,15 +16,15 @@ dependencies:
 - condition: etcd.enabled
   name: etcd
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 3.x.x
+  version: 12.0.18-legacy
 - condition: kafka.enabled
   name: kafka
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 4.x.x
+  version: 32.4.3-legacy
 - condition: minio.enabled
   name: minio
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 2025.x.x
+  version: 17.0.21-legacy
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -47,4 +47,4 @@ maintainers:
 name: milvus
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/milvus
-version: 16.0.1-legacy
+version: 16.0.2-legacy

--- a/bitnami/mlflow/Chart.yaml
+++ b/bitnami/mlflow/Chart.yaml
@@ -15,11 +15,11 @@ dependencies:
 - condition: minio.enabled
   name: minio
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 2025.x.x
+  version: 17.0.21-legacy
 - condition: postgresql.enabled
   name: postgresql
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 17.x.x
+  version: 16.7.27-legacy
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -42,4 +42,4 @@ maintainers:
 name: mlflow
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mlflow
-version: 5.1.16-legacy
+version: 5.1.17-legacy

--- a/bitnami/moodle/Chart.yaml
+++ b/bitnami/moodle/Chart.yaml
@@ -15,7 +15,7 @@ dependencies:
 - condition: mariadb.enabled
   name: mariadb
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 12.x.x
+  version: 22.0.0-legacy
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -36,4 +36,4 @@ maintainers:
 name: moodle
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/moodle
-version: 28.0.0-legacy
+version: 28.0.1-legacy

--- a/bitnami/nessie/Chart.yaml
+++ b/bitnami/nessie/Chart.yaml
@@ -15,7 +15,7 @@ dependencies:
 - condition: postgresql.enabled
   name: postgresql
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 17.x.x
+  version: 16.7.27-legacy
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -35,4 +35,4 @@ maintainers:
 name: nessie
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/nessie
-version: 2.0.33-legacy
+version: 2.0.34-legacy

--- a/bitnami/oauth2-proxy/Chart.yaml
+++ b/bitnami/oauth2-proxy/Chart.yaml
@@ -13,7 +13,7 @@ dependencies:
 - condition: redis.enabled
   name: redis
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 8.x.x
+  version: 22.0.6-legacy
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -37,4 +37,4 @@ maintainers:
 name: oauth2-proxy
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/oauth2-proxy
-version: 8.0.2-legacy
+version: 8.0.3-legacy

--- a/bitnami/odoo/Chart.yaml
+++ b/bitnami/odoo/Chart.yaml
@@ -13,7 +13,7 @@ dependencies:
 - condition: postgresql.enabled
   name: postgresql
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 17.x.x
+  version: 16.7.27-legacy
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -36,4 +36,4 @@ maintainers:
 name: odoo
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/odoo
-version: 28.2.10-legacy
+version: 28.2.11-legacy

--- a/bitnami/parse/Chart.yaml
+++ b/bitnami/parse/Chart.yaml
@@ -14,7 +14,7 @@ appVersion: 8.2.3
 dependencies:
 - name: mongodb
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 8.x.x
+  version: 16.5.45-legacy
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -38,4 +38,4 @@ maintainers:
 name: parse
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/parse
-version: 25.1.15-legacy
+version: 25.1.16-legacy

--- a/bitnami/phpmyadmin/Chart.yaml
+++ b/bitnami/phpmyadmin/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
   - phpmyadmin-database
-  version: 12.x.x
+  version: 22.0.0-legacy
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -37,4 +37,4 @@ maintainers:
 name: phpmyadmin
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/phpmyadmin
-version: 20.0.0-legacy
+version: 20.0.1-legacy

--- a/bitnami/redmine/Chart.yaml
+++ b/bitnami/redmine/Chart.yaml
@@ -14,11 +14,11 @@ dependencies:
 - condition: postgresql.enabled
   name: postgresql
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 17.x.x
+  version: 16.7.27-legacy
 - condition: mariadb.enabled
   name: mariadb
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 12.x.x
+  version: 22.0.0-legacy
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -44,4 +44,4 @@ maintainers:
 name: redmine
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/redmine
-version: 34.0.0-legacy
+version: 34.0.1-legacy

--- a/bitnami/schema-registry/Chart.yaml
+++ b/bitnami/schema-registry/Chart.yaml
@@ -13,7 +13,7 @@ dependencies:
 - condition: kafka.enabled
   name: kafka
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 4.x.x
+  version: 32.4.3-legacy
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -36,4 +36,4 @@ maintainers:
 name: schema-registry
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/schema-registry
-version: 26.0.5-legacy
+version: 26.0.6-legacy

--- a/bitnami/seaweedfs/Chart.yaml
+++ b/bitnami/seaweedfs/Chart.yaml
@@ -18,13 +18,13 @@ dependencies:
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
   - seaweedfs-database
-  version: 12.x.x
+  version: 22.0.0-legacy
 - condition: postgresql.enabled
   name: postgresql
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
   - seaweedfs-database
-  version: 17.x.x
+  version: 16.7.27-legacy
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -46,4 +46,4 @@ maintainers:
 name: seaweedfs
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/seaweedfs
-version: 6.0.1-legacy
+version: 6.0.2-legacy

--- a/bitnami/sonarqube/Chart.yaml
+++ b/bitnami/sonarqube/Chart.yaml
@@ -15,7 +15,7 @@ dependencies:
 - condition: postgresql.enabled
   name: postgresql
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 17.x.x
+  version: 16.7.27-legacy
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -37,5 +37,5 @@ maintainers:
 name: sonarqube
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/sonarqube
-version: 8.1.17-legacy
+version: 8.1.18-legacy
 # Trigger release for chart repository publishing

--- a/bitnami/superset/Chart.yaml
+++ b/bitnami/superset/Chart.yaml
@@ -13,11 +13,11 @@ dependencies:
 - condition: redis.enabled
   name: redis
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 8.x.x
+  version: 22.0.6-legacy
 - condition: postgresql.enabled
   name: postgresql
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 17.x.x
+  version: 16.7.27-legacy
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -35,4 +35,4 @@ maintainers:
 name: superset
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/superset
-version: 5.0.0-legacy
+version: 5.0.1-legacy

--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -14,7 +14,7 @@ dependencies:
 - condition: minio.enabled
   name: minio
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 2025.x.x
+  version: 17.0.21-legacy
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -36,4 +36,4 @@ maintainers:
 name: thanos
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/thanos
-version: 17.3.1-legacy
+version: 17.3.2-legacy

--- a/bitnami/wordpress/Chart.yaml
+++ b/bitnami/wordpress/Chart.yaml
@@ -15,11 +15,11 @@ dependencies:
 - condition: memcached.enabled
   name: memcached
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 1.x.x
+  version: 7.9.7-legacy
 - condition: mariadb.enabled
   name: mariadb
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 12.x.x
+  version: 22.0.0-legacy
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -44,4 +44,4 @@ maintainers:
 name: wordpress
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/wordpress
-version: 26.0.0-legacy
+version: 26.0.1-legacy

--- a/bitnami/zipkin/Chart.yaml
+++ b/bitnami/zipkin/Chart.yaml
@@ -14,7 +14,7 @@ dependencies:
 - condition: cassandra.enabled
   name: cassandra
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 5.x.x
+  version: 12.3.11-legacy
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -34,4 +34,4 @@ maintainers:
 name: zipkin
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/zipkin
-version: 1.3.11-legacy
+version: 1.3.12-legacy


### PR DESCRIPTION
Increment patch versions for 41 charts that had internal dependency constraints updated:
- airflow: 25.0.2-legacy -> 25.0.3-legacy
- apisix: 6.0.0-legacy -> 6.0.1-legacy
- appsmith: 7.0.3-legacy -> 7.0.4-legacy
- Plus 38 other charts with dependency changes

This follows semantic versioning - patch increment for dependency updates.

🤖 Generated with [Claude Code](https://claude.ai/code)