### PR TITLE
Fix semantic versioning for all charts

### DIFF
--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -14,11 +14,11 @@ dependencies:
 - condition: redis.enabled
   name: redis
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 22.0.6-legacy
+  version: 22.x.x
 - condition: postgresql.enabled
   name: postgresql
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 16.7.27-legacy
+  version: 16.x.x
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -40,4 +40,4 @@ maintainers:
 name: airflow
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/airflow
-version: 25.0.3-legacy
+version: 25.0.4

--- a/bitnami/apache/Chart.yaml
+++ b/bitnami/apache/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: apache
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/apache
-version: 11.4.29-legacy
+version: 11.4.30

--- a/bitnami/apisix/Chart.yaml
+++ b/bitnami/apisix/Chart.yaml
@@ -15,7 +15,7 @@ dependencies:
 - condition: etcd.enabled
   name: etcd
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 12.0.18-legacy
+  version: 12.x.x
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -41,4 +41,4 @@ maintainers:
 name: apisix
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/apisix
-version: 6.0.1-legacy
+version: 6.0.2

--- a/bitnami/appsmith/Chart.yaml
+++ b/bitnami/appsmith/Chart.yaml
@@ -15,11 +15,11 @@ dependencies:
 - condition: redis.enabled
   name: redis
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 22.0.6-legacy
+  version: 22.x.x
 - condition: mongodb.enabled
   name: mongodb
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 16.5.45-legacy
+  version: 16.x.x
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -38,4 +38,4 @@ maintainers:
 name: appsmith
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/appsmith
-version: 7.0.4-legacy
+version: 7.0.5

--- a/bitnami/argo-cd/Chart.yaml
+++ b/bitnami/argo-cd/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
 - condition: redis.enabled
   name: redis
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 22.0.6-legacy
+  version: 22.x.x
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -36,4 +36,4 @@ maintainers:
 name: argo-cd
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/argo-cd
-version: 11.0.1-legacy
+version: 11.0.2

--- a/bitnami/argo-workflows/Chart.yaml
+++ b/bitnami/argo-workflows/Chart.yaml
@@ -15,11 +15,11 @@ dependencies:
 - condition: postgresql.enabled
   name: postgresql
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 16.7.27-legacy
+  version: 16.x.x
 - condition: mysql.enabled
   name: mysql
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 14.0.3-legacy
+  version: 14.x.x
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -41,4 +41,4 @@ maintainers:
 name: argo-workflows
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/argo-workflows
-version: 13.0.7-legacy
+version: 13.0.8

--- a/bitnami/aspnet-core/Chart.yaml
+++ b/bitnami/aspnet-core/Chart.yaml
@@ -31,4 +31,4 @@ maintainers:
 name: aspnet-core
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/aspnet-core
-version: 7.0.35-legacy
+version: 7.0.36

--- a/bitnami/cadvisor/Chart.yaml
+++ b/bitnami/cadvisor/Chart.yaml
@@ -29,4 +29,4 @@ maintainers:
 name: cadvisor
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/cadvisor
-version: 0.1.13-legacy
+version: 0.1.14

--- a/bitnami/cassandra/Chart.yaml
+++ b/bitnami/cassandra/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: cassandra
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/cassandra
-version: 12.3.11-legacy
+version: 12.3.12

--- a/bitnami/cert-manager/Chart.yaml
+++ b/bitnami/cert-manager/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: cert-manager
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/cert-manager
-version: 1.5.14-legacy
+version: 1.5.15

--- a/bitnami/chainloop/Chart.yaml
+++ b/bitnami/chainloop/Chart.yaml
@@ -21,7 +21,7 @@ dependencies:
 - condition: postgresql.enabled
   name: postgresql
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 16.7.27-legacy
+  version: 16.x.x
 - condition: development
   name: vault
   repository: https://portswigger-cloud.github.io/legacy-charts/
@@ -57,4 +57,4 @@ maintainers:
 name: chainloop
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/chainloop
-version: 4.0.75-legacy
+version: 4.0.76

--- a/bitnami/cilium/Chart.yaml
+++ b/bitnami/cilium/Chart.yaml
@@ -20,7 +20,7 @@ dependencies:
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
   - cilium-database
-  version: 12.0.18-legacy
+  version: 12.x.x
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -42,4 +42,4 @@ maintainers:
 name: cilium
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/cilium
-version: 3.1.10-legacy
+version: 3.1.11

--- a/bitnami/clickhouse-operator/Chart.yaml
+++ b/bitnami/clickhouse-operator/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: clickhouse-operator
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/clickhouse-operator
-version: 0.2.33-legacy
+version: 0.2.34

--- a/bitnami/clickhouse/Chart.yaml
+++ b/bitnami/clickhouse/Chart.yaml
@@ -31,4 +31,4 @@ maintainers:
 name: clickhouse
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/clickhouse
-version: 9.4.3-legacy
+version: 9.4.4

--- a/bitnami/cloudnative-pg/Chart.yaml
+++ b/bitnami/cloudnative-pg/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: cloudnative-pg
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/cloudnative-pg
-version: 1.0.11-legacy
+version: 1.0.12

--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -22,4 +22,4 @@ maintainers:
 name: common
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/common
-version: 2.31.4-legacy
+version: 2.31.5

--- a/bitnami/concourse/Chart.yaml
+++ b/bitnami/concourse/Chart.yaml
@@ -14,7 +14,7 @@ dependencies:
 - condition: postgresql.enabled
   name: postgresql
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 16.7.27-legacy
+  version: 16.x.x
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -38,4 +38,4 @@ maintainers:
 name: concourse
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/concourse
-version: 5.1.46-legacy
+version: 5.1.47

--- a/bitnami/consul/Chart.yaml
+++ b/bitnami/consul/Chart.yaml
@@ -31,4 +31,4 @@ maintainers:
 name: consul
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/consul
-version: 11.4.32-legacy
+version: 11.4.33

--- a/bitnami/contour/Chart.yaml
+++ b/bitnami/contour/Chart.yaml
@@ -31,4 +31,4 @@ maintainers:
 name: contour
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/contour
-version: 21.1.4-legacy
+version: 21.1.5

--- a/bitnami/deepspeed/Chart.yaml
+++ b/bitnami/deepspeed/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: deepspeed
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/deepspeed
-version: 2.3.50-legacy
+version: 2.3.51

--- a/bitnami/discourse/Chart.yaml
+++ b/bitnami/discourse/Chart.yaml
@@ -14,11 +14,11 @@ dependencies:
 - condition: redis.enabled
   name: redis
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 22.0.6-legacy
+  version: 22.x.x
 - condition: postgresql.enabled
   name: postgresql
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 16.7.27-legacy
+  version: 16.x.x
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -38,4 +38,4 @@ maintainers:
 name: discourse
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/discourse
-version: 17.0.2-legacy
+version: 17.0.3

--- a/bitnami/dremio/Chart.yaml
+++ b/bitnami/dremio/Chart.yaml
@@ -15,7 +15,7 @@ dependencies:
 - condition: minio.enabled
   name: minio
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 17.0.21-legacy
+  version: 17.x.x
 - condition: zookeeper.enabled
   name: zookeeper
   repository: https://portswigger-cloud.github.io/legacy-charts/
@@ -38,4 +38,4 @@ maintainers:
 name: dremio
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/dremio
-version: 3.0.14-legacy
+version: 3.0.15

--- a/bitnami/drupal/Chart.yaml
+++ b/bitnami/drupal/Chart.yaml
@@ -15,7 +15,7 @@ dependencies:
 - condition: mariadb.enabled
   name: mariadb
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 22.0.0-legacy
+  version: 22.x.x
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -40,4 +40,4 @@ maintainers:
 name: drupal
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/drupal
-version: 23.0.1-legacy
+version: 23.0.2

--- a/bitnami/ejbca/Chart.yaml
+++ b/bitnami/ejbca/Chart.yaml
@@ -15,7 +15,7 @@ dependencies:
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
   - ejbca-database
-  version: 22.0.0-legacy
+  version: 22.x.x
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -36,4 +36,4 @@ maintainers:
 name: ejbca
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/ejbca
-version: 19.0.1-legacy
+version: 19.0.2

--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: elasticsearch
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/elasticsearch
-version: 22.1.6-legacy
+version: 22.1.7

--- a/bitnami/envoy-gateway/Chart.yaml
+++ b/bitnami/envoy-gateway/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: envoy-gateway
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/envoy-gateway
-version: 2.0.4-legacy
+version: 2.0.5

--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: etcd
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/etcd
-version: 12.0.18-legacy
+version: 12.0.19

--- a/bitnami/external-dns/Chart.yaml
+++ b/bitnami/external-dns/Chart.yaml
@@ -29,4 +29,4 @@ maintainers:
 name: external-dns
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/external-dns
-version: 9.0.3-legacy
+version: 9.0.4

--- a/bitnami/flink/Chart.yaml
+++ b/bitnami/flink/Chart.yaml
@@ -29,4 +29,4 @@ maintainers:
 name: flink
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/flink
-version: 2.0.7-legacy
+version: 2.0.8

--- a/bitnami/fluent-bit/Chart.yaml
+++ b/bitnami/fluent-bit/Chart.yaml
@@ -30,4 +30,4 @@ maintainers:
 name: fluent-bit
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/fluent-bit
-version: 3.1.13-legacy
+version: 3.1.14

--- a/bitnami/fluentd/Chart.yaml
+++ b/bitnami/fluentd/Chart.yaml
@@ -31,4 +31,4 @@ maintainers:
 name: fluentd
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/fluentd
-version: 7.2.5-legacy
+version: 7.2.6

--- a/bitnami/flux/Chart.yaml
+++ b/bitnami/flux/Chart.yaml
@@ -38,4 +38,4 @@ maintainers:
 name: flux
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/flux
-version: 2.4.36-legacy
+version: 2.4.37

--- a/bitnami/ghost/Chart.yaml
+++ b/bitnami/ghost/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
   - ghost-database
-  version: 14.0.3-legacy
+  version: 14.x.x
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -41,4 +41,4 @@ maintainers:
 name: ghost
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/ghost
-version: 25.0.5-legacy
+version: 25.0.6

--- a/bitnami/gitea/Chart.yaml
+++ b/bitnami/gitea/Chart.yaml
@@ -14,7 +14,7 @@ dependencies:
 - condition: postgresql.enabled
   name: postgresql
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 16.7.27-legacy
+  version: 16.x.x
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -37,4 +37,4 @@ maintainers:
 name: gitea
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/gitea
-version: 3.2.23-legacy
+version: 3.2.24

--- a/bitnami/gitlab-runner/Chart.yaml
+++ b/bitnami/gitlab-runner/Chart.yaml
@@ -30,4 +30,4 @@ maintainers:
 name: gitlab-runner
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/gitlab-runner
-version: 1.1.8-legacy
+version: 1.1.9

--- a/bitnami/grafana-alloy/Chart.yaml
+++ b/bitnami/grafana-alloy/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: grafana-alloy
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/grafana-alloy
-version: 1.0.7-legacy
+version: 1.0.8

--- a/bitnami/grafana-k6-operator/Chart.yaml
+++ b/bitnami/grafana-k6-operator/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: grafana-k6-operator
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/grafana-k6-operator
-version: 1.0.11-legacy
+version: 1.0.12

--- a/bitnami/grafana-loki/Chart.yaml
+++ b/bitnami/grafana-loki/Chart.yaml
@@ -21,22 +21,22 @@ dependencies:
   condition: memcachedchunks.enabled
   name: memcached
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 7.9.7-legacy
+  version: 7.x.x
 - alias: memcachedfrontend
   condition: memcachedfrontend.enabled
   name: memcached
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 7.9.7-legacy
+  version: 7.x.x
 - alias: memcachedindexqueries
   condition: memcachedindexqueries.enabled
   name: memcached
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 7.9.7-legacy
+  version: 7.x.x
 - alias: memcachedindexwrites
   condition: memcachedindexwrites.enabled
   name: memcached
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 7.9.7-legacy
+  version: 7.x.x
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -58,4 +58,4 @@ maintainers:
 name: grafana-loki
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/grafana-loki
-version: 6.0.7-legacy
+version: 6.0.8

--- a/bitnami/grafana-mimir/Chart.yaml
+++ b/bitnami/grafana-mimir/Chart.yaml
@@ -16,27 +16,27 @@ dependencies:
 - condition: minio.enabled
   name: minio
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 17.0.21-legacy
+  version: 17.x.x
 - alias: memcachedmetadata
   condition: memcachedmetadata.enabled
   name: memcached
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 7.9.7-legacy
+  version: 7.x.x
 - alias: memcachedindex
   condition: memcachedindex.enabled
   name: memcached
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 7.9.7-legacy
+  version: 7.x.x
 - alias: memcachedfrontend
   condition: memcachedfrontend.enabled
   name: memcached
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 7.9.7-legacy
+  version: 7.x.x
 - alias: memcachedchunks
   condition: memcachedchunks.enabled
   name: memcached
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 7.9.7-legacy
+  version: 7.x.x
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -57,4 +57,4 @@ maintainers:
 name: grafana-mimir
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/grafana-mimir
-version: 3.0.19-legacy
+version: 3.0.20

--- a/bitnami/grafana-operator/Chart.yaml
+++ b/bitnami/grafana-operator/Chart.yaml
@@ -30,5 +30,5 @@ maintainers:
 name: grafana-operator
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/grafana-operator
-version: 4.9.37-legacy
+version: 4.9.38
 # Trigger release for chart repository publishing

--- a/bitnami/grafana-tempo/Chart.yaml
+++ b/bitnami/grafana-tempo/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
 - condition: memcached.enabled
   name: memcached
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 7.9.7-legacy
+  version: 7.x.x
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -38,4 +38,4 @@ maintainers:
 name: grafana-tempo
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/grafana-tempo
-version: 4.0.18-legacy
+version: 4.0.19

--- a/bitnami/grafana/Chart.yaml
+++ b/bitnami/grafana/Chart.yaml
@@ -31,4 +31,4 @@ maintainers:
 name: grafana
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/grafana
-version: 12.1.8-legacy
+version: 12.1.9

--- a/bitnami/haproxy/Chart.yaml
+++ b/bitnami/haproxy/Chart.yaml
@@ -30,4 +30,4 @@ maintainers:
 name: haproxy
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/haproxy
-version: 2.2.34-legacy
+version: 2.2.35

--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -21,11 +21,11 @@ dependencies:
 - condition: redis.enabled
   name: redis
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 22.0.6-legacy
+  version: 22.x.x
 - condition: postgresql.enabled
   name: postgresql
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 16.7.27-legacy
+  version: 16.x.x
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -47,4 +47,4 @@ maintainers:
 name: harbor
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/harbor
-version: 27.0.4-legacy
+version: 27.0.5

--- a/bitnami/influxdb/Chart.yaml
+++ b/bitnami/influxdb/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: influxdb
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/influxdb
-version: 7.1.18-legacy
+version: 7.1.19

--- a/bitnami/jaeger/Chart.yaml
+++ b/bitnami/jaeger/Chart.yaml
@@ -19,7 +19,7 @@ dependencies:
 - condition: cassandra.enabled
   name: cassandra
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 12.3.11-legacy
+  version: 12.x.x
 description: Jaeger is a distributed tracing system. It is used for monitoring and
   troubleshooting microservices-based distributed systems.
 home: https://bitnami.com
@@ -34,4 +34,4 @@ maintainers:
 name: jaeger
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/jaeger
-version: 6.0.6-legacy
+version: 6.0.7

--- a/bitnami/janusgraph/Chart.yaml
+++ b/bitnami/janusgraph/Chart.yaml
@@ -15,7 +15,7 @@ dependencies:
 - condition: storageBackend.cassandra.enabled
   name: cassandra
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 12.3.11-legacy
+  version: 12.x.x
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -36,4 +36,4 @@ maintainers:
 name: janusgraph
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/janusgraph
-version: 1.4.11-legacy
+version: 1.4.12

--- a/bitnami/jenkins/Chart.yaml
+++ b/bitnami/jenkins/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: jenkins
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/jenkins
-version: 13.6.17-legacy
+version: 13.6.18

--- a/bitnami/jupyterhub/Chart.yaml
+++ b/bitnami/jupyterhub/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
 - condition: postgresql.enabled
   name: postgresql
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 16.7.27-legacy
+  version: 16.x.x
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -36,4 +36,4 @@ maintainers:
 name: jupyterhub
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/jupyterhub
-version: 10.0.6-legacy
+version: 10.0.7

--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: kafka
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kafka
-version: 32.4.3-legacy
+version: 32.4.4

--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -14,7 +14,7 @@ dependencies:
 - condition: postgresql.enabled
   name: postgresql
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 16.7.27-legacy
+  version: 16.x.x
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -34,4 +34,4 @@ maintainers:
 name: keycloak
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/keycloak
-version: 25.2.1-legacy
+version: 25.2.2

--- a/bitnami/keydb/Chart.yaml
+++ b/bitnami/keydb/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: keydb
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/keydb
-version: 0.5.22-legacy
+version: 0.5.23

--- a/bitnami/kiam/Chart.yaml
+++ b/bitnami/kiam/Chart.yaml
@@ -29,4 +29,4 @@ maintainers:
 name: kiam
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kiam
-version: 2.3.16-legacy
+version: 2.3.17

--- a/bitnami/kibana/Chart.yaml
+++ b/bitnami/kibana/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: kibana
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kibana
-version: 12.1.10-legacy
+version: 12.1.11

--- a/bitnami/kong/Chart.yaml
+++ b/bitnami/kong/Chart.yaml
@@ -14,7 +14,7 @@ dependencies:
 - condition: postgresql.enabled
   name: postgresql
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 16.7.27-legacy
+  version: 16.x.x
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -23,7 +23,7 @@ dependencies:
 - condition: cassandra.enabled
   name: cassandra
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 12.3.11-legacy
+  version: 12.x.x
 description: Kong is an open source Microservice API gateway and platform designed
   for managing microservices requests of high-availability, fault-tolerance, and distributed
   systems.
@@ -44,4 +44,4 @@ maintainers:
 name: kong
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kong
-version: 15.4.22-legacy
+version: 15.4.23

--- a/bitnami/kube-arangodb/Chart.yaml
+++ b/bitnami/kube-arangodb/Chart.yaml
@@ -31,4 +31,4 @@ maintainers:
 name: kube-arangodb
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kube-arangodb
-version: 0.1.23-legacy
+version: 0.1.24

--- a/bitnami/kube-prometheus-crds/Chart.yaml
+++ b/bitnami/kube-prometheus-crds/Chart.yaml
@@ -21,4 +21,4 @@ maintainers:
 name: kube-prometheus-crds
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kube-prometheus-crds
-version: 0.1.0-legacy
+version: 0.1.1

--- a/bitnami/kube-prometheus/Chart.yaml
+++ b/bitnami/kube-prometheus/Chart.yaml
@@ -46,5 +46,5 @@ maintainers:
 name: kube-prometheus
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kube-prometheus
-version: 11.3.10-legacy
+version: 11.3.12
 # Trigger release for chart repository publishing

--- a/bitnami/kube-state-metrics/Chart.yaml
+++ b/bitnami/kube-state-metrics/Chart.yaml
@@ -29,5 +29,5 @@ maintainers:
 name: kube-state-metrics
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kube-state-metrics
-version: 5.1.0-legacy
+version: 5.1.1
 # Trigger release for chart repository publishing

--- a/bitnami/kuberay/Chart.yaml
+++ b/bitnami/kuberay/Chart.yaml
@@ -31,4 +31,4 @@ maintainers:
 name: kuberay
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kuberay
-version: 1.4.29-legacy
+version: 1.4.30

--- a/bitnami/kubernetes-event-exporter/Chart.yaml
+++ b/bitnami/kubernetes-event-exporter/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: kubernetes-event-exporter
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kubernetes-event-exporter
-version: 3.6.3-legacy
+version: 3.6.4

--- a/bitnami/logstash/Chart.yaml
+++ b/bitnami/logstash/Chart.yaml
@@ -31,4 +31,4 @@ maintainers:
 name: logstash
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/logstash
-version: 7.0.11-legacy
+version: 7.0.12

--- a/bitnami/mariadb-galera/Chart.yaml
+++ b/bitnami/mariadb-galera/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: mariadb-galera
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mariadb-galera
-version: 16.0.1-legacy
+version: 16.0.2

--- a/bitnami/mariadb/Chart.yaml
+++ b/bitnami/mariadb/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: mariadb
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mariadb
-version: 22.0.0-legacy
+version: 22.0.1

--- a/bitnami/mastodon/Chart.yaml
+++ b/bitnami/mastodon/Chart.yaml
@@ -14,23 +14,23 @@ dependencies:
 - condition: redis.enabled
   name: redis
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 22.0.6-legacy
+  version: 22.x.x
 - condition: postgresql.enabled
   name: postgresql
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 16.7.27-legacy
+  version: 16.x.x
 - condition: elasticsearch.enabled
   name: elasticsearch
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 22.1.6-legacy
+  version: 22.x.x
 - condition: minio.enabled
   name: minio
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 17.0.21-legacy
+  version: 17.x.x
 - condition: apache.enabled
   name: apache
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 11.4.29-legacy
+  version: 11.x.x
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -49,4 +49,4 @@ maintainers:
 name: mastodon
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mastodon
-version: 14.0.1-legacy
+version: 14.0.2

--- a/bitnami/matomo/Chart.yaml
+++ b/bitnami/matomo/Chart.yaml
@@ -15,7 +15,7 @@ dependencies:
 - condition: mariadb.enabled
   name: mariadb
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 22.0.0-legacy
+  version: 22.x.x
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -38,4 +38,4 @@ maintainers:
 name: matomo
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/matomo
-version: 11.0.1-legacy
+version: 11.0.2

--- a/bitnami/memcached/Chart.yaml
+++ b/bitnami/memcached/Chart.yaml
@@ -31,4 +31,4 @@ maintainers:
 name: memcached
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/memcached
-version: 7.9.7-legacy
+version: 7.9.8

--- a/bitnami/metallb/Chart.yaml
+++ b/bitnami/metallb/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: metallb
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/metallb
-version: 6.4.22-legacy
+version: 6.4.23

--- a/bitnami/metrics-server/Chart.yaml
+++ b/bitnami/metrics-server/Chart.yaml
@@ -30,5 +30,5 @@ maintainers:
 name: metrics-server
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/metrics-server
-version: 7.4.12-legacy
+version: 7.4.13
 # Trigger release for chart repository publishing

--- a/bitnami/milvus/Chart.yaml
+++ b/bitnami/milvus/Chart.yaml
@@ -16,15 +16,15 @@ dependencies:
 - condition: etcd.enabled
   name: etcd
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 12.0.18-legacy
+  version: 12.x.x
 - condition: kafka.enabled
   name: kafka
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 32.4.3-legacy
+  version: 32.x.x
 - condition: minio.enabled
   name: minio
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 17.0.21-legacy
+  version: 17.x.x
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -47,4 +47,4 @@ maintainers:
 name: milvus
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/milvus
-version: 16.0.2-legacy
+version: 16.0.3

--- a/bitnami/minio-operator/Chart.yaml
+++ b/bitnami/minio-operator/Chart.yaml
@@ -31,4 +31,4 @@ maintainers:
 name: minio-operator
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/minio-operator
-version: 0.2.9-legacy
+version: 0.2.10

--- a/bitnami/minio/Chart.yaml
+++ b/bitnami/minio/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: minio
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/minio
-version: 17.0.21-legacy
+version: 17.0.22

--- a/bitnami/mlflow/Chart.yaml
+++ b/bitnami/mlflow/Chart.yaml
@@ -15,11 +15,11 @@ dependencies:
 - condition: minio.enabled
   name: minio
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 17.0.21-legacy
+  version: 17.x.x
 - condition: postgresql.enabled
   name: postgresql
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 16.7.27-legacy
+  version: 16.x.x
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -42,4 +42,4 @@ maintainers:
 name: mlflow
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mlflow
-version: 5.1.17-legacy
+version: 5.1.18

--- a/bitnami/mongodb-sharded/Chart.yaml
+++ b/bitnami/mongodb-sharded/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: mongodb-sharded
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mongodb-sharded
-version: 9.4.12-legacy
+version: 9.4.13

--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -37,4 +37,4 @@ maintainers:
 name: mongodb
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mongodb
-version: 16.5.45-legacy
+version: 16.5.46

--- a/bitnami/moodle/Chart.yaml
+++ b/bitnami/moodle/Chart.yaml
@@ -15,7 +15,7 @@ dependencies:
 - condition: mariadb.enabled
   name: mariadb
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 22.0.0-legacy
+  version: 22.x.x
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -36,4 +36,4 @@ maintainers:
 name: moodle
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/moodle
-version: 28.0.1-legacy
+version: 28.0.2

--- a/bitnami/multus-cni/Chart.yaml
+++ b/bitnami/multus-cni/Chart.yaml
@@ -30,4 +30,4 @@ maintainers:
 name: multus-cni
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/multus-cni
-version: 2.2.21-legacy
+version: 2.2.22

--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: mysql
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mysql
-version: 14.0.3-legacy
+version: 14.0.4

--- a/bitnami/nats/Chart.yaml
+++ b/bitnami/nats/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: nats
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/nats
-version: 9.0.28-legacy
+version: 9.0.29

--- a/bitnami/neo4j/Chart.yaml
+++ b/bitnami/neo4j/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: neo4j
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/neo4j
-version: 0.4.13-legacy
+version: 0.4.14

--- a/bitnami/nessie/Chart.yaml
+++ b/bitnami/nessie/Chart.yaml
@@ -15,7 +15,7 @@ dependencies:
 - condition: postgresql.enabled
   name: postgresql
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 16.7.27-legacy
+  version: 16.x.x
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -35,4 +35,4 @@ maintainers:
 name: nessie
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/nessie
-version: 2.0.34-legacy
+version: 2.0.35

--- a/bitnami/nginx-ingress-controller/Chart.yaml
+++ b/bitnami/nginx-ingress-controller/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: nginx-ingress-controller
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/nginx-ingress-controller
-version: 12.0.7-legacy
+version: 12.0.8

--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: nginx
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/nginx
-version: 21.1.23-legacy
+version: 21.1.24

--- a/bitnami/node-exporter/Chart.yaml
+++ b/bitnami/node-exporter/Chart.yaml
@@ -29,5 +29,5 @@ maintainers:
 name: node-exporter
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/node-exporter
-version: 4.5.19-legacy
+version: 4.5.20
 # Trigger release for chart repository publishing

--- a/bitnami/oauth2-proxy/Chart.yaml
+++ b/bitnami/oauth2-proxy/Chart.yaml
@@ -13,7 +13,7 @@ dependencies:
 - condition: redis.enabled
   name: redis
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 22.0.6-legacy
+  version: 22.x.x
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -37,4 +37,4 @@ maintainers:
 name: oauth2-proxy
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/oauth2-proxy
-version: 8.0.3-legacy
+version: 8.0.4

--- a/bitnami/odoo/Chart.yaml
+++ b/bitnami/odoo/Chart.yaml
@@ -13,7 +13,7 @@ dependencies:
 - condition: postgresql.enabled
   name: postgresql
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 16.7.27-legacy
+  version: 16.x.x
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -36,4 +36,4 @@ maintainers:
 name: odoo
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/odoo
-version: 28.2.11-legacy
+version: 28.2.12

--- a/bitnami/opensearch/Chart.yaml
+++ b/bitnami/opensearch/Chart.yaml
@@ -30,4 +30,4 @@ maintainers:
 name: opensearch
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/opensearch
-version: 2.0.10-legacy
+version: 2.0.11

--- a/bitnami/parse/Chart.yaml
+++ b/bitnami/parse/Chart.yaml
@@ -14,7 +14,7 @@ appVersion: 8.2.3
 dependencies:
 - name: mongodb
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 16.5.45-legacy
+  version: 16.x.x
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -38,4 +38,4 @@ maintainers:
 name: parse
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/parse
-version: 25.1.16-legacy
+version: 25.1.17

--- a/bitnami/phpmyadmin/Chart.yaml
+++ b/bitnami/phpmyadmin/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
   - phpmyadmin-database
-  version: 22.0.0-legacy
+  version: 22.x.x
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -37,4 +37,4 @@ maintainers:
 name: phpmyadmin
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/phpmyadmin
-version: 20.0.1-legacy
+version: 20.0.2

--- a/bitnami/pinniped/Chart.yaml
+++ b/bitnami/pinniped/Chart.yaml
@@ -29,4 +29,4 @@ maintainers:
 name: pinniped
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/pinniped
-version: 2.4.23-legacy
+version: 2.4.24

--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: postgresql-ha
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/postgresql-ha
-version: 16.3.2-legacy
+version: 16.3.3

--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: postgresql
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/postgresql
-version: 16.7.27-legacy
+version: 16.7.28

--- a/bitnami/prometheus/Chart.yaml
+++ b/bitnami/prometheus/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: prometheus
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/prometheus
-version: 2.1.23-legacy
+version: 2.1.24

--- a/bitnami/pytorch/Chart.yaml
+++ b/bitnami/pytorch/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: pytorch
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/pytorch
-version: 4.3.31-legacy
+version: 4.3.32

--- a/bitnami/rabbitmq-cluster-operator/Chart.yaml
+++ b/bitnami/rabbitmq-cluster-operator/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: rabbitmq-cluster-operator
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/rabbitmq-cluster-operator
-version: 4.4.34-legacy
+version: 4.4.35

--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -30,4 +30,4 @@ maintainers:
 name: rabbitmq
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/rabbitmq
-version: 16.0.14-legacy
+version: 16.0.15

--- a/bitnami/redis-cluster/Chart.yaml
+++ b/bitnami/redis-cluster/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: redis-cluster
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/redis-cluster
-version: 13.0.4-legacy
+version: 13.0.5

--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: redis
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/redis
-version: 22.0.6-legacy
+version: 22.0.7

--- a/bitnami/redmine/Chart.yaml
+++ b/bitnami/redmine/Chart.yaml
@@ -14,11 +14,11 @@ dependencies:
 - condition: postgresql.enabled
   name: postgresql
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 16.7.27-legacy
+  version: 16.x.x
 - condition: mariadb.enabled
   name: mariadb
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 22.0.0-legacy
+  version: 22.x.x
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -44,4 +44,4 @@ maintainers:
 name: redmine
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/redmine
-version: 34.0.1-legacy
+version: 34.0.2

--- a/bitnami/schema-registry/Chart.yaml
+++ b/bitnami/schema-registry/Chart.yaml
@@ -13,7 +13,7 @@ dependencies:
 - condition: kafka.enabled
   name: kafka
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 32.4.3-legacy
+  version: 32.x.x
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -36,4 +36,4 @@ maintainers:
 name: schema-registry
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/schema-registry
-version: 26.0.6-legacy
+version: 26.0.7

--- a/bitnami/scylladb/Chart.yaml
+++ b/bitnami/scylladb/Chart.yaml
@@ -31,4 +31,4 @@ maintainers:
 name: scylladb
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/scylladb
-version: 5.0.6-legacy
+version: 5.0.7

--- a/bitnami/sealed-secrets/Chart.yaml
+++ b/bitnami/sealed-secrets/Chart.yaml
@@ -30,5 +30,5 @@ maintainers:
 name: sealed-secrets
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/sealed-secrets
-version: 2.5.19-legacy
+version: 2.5.20
 # Trigger release for chart repository publishing

--- a/bitnami/seaweedfs/Chart.yaml
+++ b/bitnami/seaweedfs/Chart.yaml
@@ -18,13 +18,13 @@ dependencies:
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
   - seaweedfs-database
-  version: 22.0.0-legacy
+  version: 22.x.x
 - condition: postgresql.enabled
   name: postgresql
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
   - seaweedfs-database
-  version: 16.7.27-legacy
+  version: 16.x.x
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -46,4 +46,4 @@ maintainers:
 name: seaweedfs
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/seaweedfs
-version: 6.0.2-legacy
+version: 6.0.3

--- a/bitnami/solr/Chart.yaml
+++ b/bitnami/solr/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: solr
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/solr
-version: 9.6.10-legacy
+version: 9.6.11

--- a/bitnami/sonarqube/Chart.yaml
+++ b/bitnami/sonarqube/Chart.yaml
@@ -15,7 +15,7 @@ dependencies:
 - condition: postgresql.enabled
   name: postgresql
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 16.7.27-legacy
+  version: 16.x.x
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -37,5 +37,5 @@ maintainers:
 name: sonarqube
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/sonarqube
-version: 8.1.18-legacy
+version: 8.1.19
 # Trigger release for chart repository publishing

--- a/bitnami/spark/Chart.yaml
+++ b/bitnami/spark/Chart.yaml
@@ -29,4 +29,4 @@ maintainers:
 name: spark
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/spark
-version: 10.0.3-legacy
+version: 10.0.4

--- a/bitnami/superset/Chart.yaml
+++ b/bitnami/superset/Chart.yaml
@@ -13,11 +13,11 @@ dependencies:
 - condition: redis.enabled
   name: redis
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 22.0.6-legacy
+  version: 22.x.x
 - condition: postgresql.enabled
   name: postgresql
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 16.7.27-legacy
+  version: 16.x.x
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -35,4 +35,4 @@ maintainers:
 name: superset
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/superset
-version: 5.0.1-legacy
+version: 5.0.2

--- a/bitnami/tensorflow-resnet/Chart.yaml
+++ b/bitnami/tensorflow-resnet/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: tensorflow-resnet
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/tensorflow-resnet
-version: 4.3.14-legacy
+version: 4.3.15

--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -14,7 +14,7 @@ dependencies:
 - condition: minio.enabled
   name: minio
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 17.0.21-legacy
+  version: 17.x.x
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -36,4 +36,4 @@ maintainers:
 name: thanos
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/thanos
-version: 17.3.2-legacy
+version: 17.3.3

--- a/bitnami/tomcat/Chart.yaml
+++ b/bitnami/tomcat/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: tomcat
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/tomcat
-version: 12.0.8-legacy
+version: 12.0.9

--- a/bitnami/valkey-cluster/Chart.yaml
+++ b/bitnami/valkey-cluster/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: valkey-cluster
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/valkey-cluster
-version: 3.0.24-legacy
+version: 3.0.25

--- a/bitnami/valkey/Chart.yaml
+++ b/bitnami/valkey/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: valkey
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/valkey
-version: 3.0.31-legacy
+version: 3.0.32

--- a/bitnami/vault/Chart.yaml
+++ b/bitnami/vault/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: vault
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/vault
-version: 1.9.0-legacy
+version: 1.9.1

--- a/bitnami/victoriametrics/Chart.yaml
+++ b/bitnami/victoriametrics/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: victoriametrics
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/victoriametrics
-version: 0.1.31-legacy
+version: 0.1.32

--- a/bitnami/whereabouts/Chart.yaml
+++ b/bitnami/whereabouts/Chart.yaml
@@ -30,4 +30,4 @@ maintainers:
 name: whereabouts
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/whereabouts
-version: 1.2.19-legacy
+version: 1.2.20

--- a/bitnami/wildfly/Chart.yaml
+++ b/bitnami/wildfly/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: wildfly
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/wildfly
-version: 25.0.0-legacy
+version: 25.0.1

--- a/bitnami/wordpress/Chart.yaml
+++ b/bitnami/wordpress/Chart.yaml
@@ -15,11 +15,11 @@ dependencies:
 - condition: memcached.enabled
   name: memcached
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 7.9.7-legacy
+  version: 7.x.x
 - condition: mariadb.enabled
   name: mariadb
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 22.0.0-legacy
+  version: 22.x.x
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -44,4 +44,4 @@ maintainers:
 name: wordpress
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/wordpress
-version: 26.0.1-legacy
+version: 26.0.2

--- a/bitnami/zipkin/Chart.yaml
+++ b/bitnami/zipkin/Chart.yaml
@@ -14,7 +14,7 @@ dependencies:
 - condition: cassandra.enabled
   name: cassandra
   repository: https://portswigger-cloud.github.io/legacy-charts/
-  version: 12.3.11-legacy
+  version: 12.x.x
 - name: common
   repository: https://portswigger-cloud.github.io/legacy-charts/
   tags:
@@ -34,4 +34,4 @@ maintainers:
 name: zipkin
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/zipkin
-version: 1.3.12-legacy
+version: 1.3.13

--- a/bitnami/zookeeper/Chart.yaml
+++ b/bitnami/zookeeper/Chart.yaml
@@ -28,4 +28,4 @@ maintainers:
 name: zookeeper
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/zookeeper
-version: 13.8.7-legacy
+version: 13.8.8


### PR DESCRIPTION
Remove -legacy suffix and use proper semantic versioning:
- All chart versions incremented (patch bump for dependency changes)
- Dependency constraints fixed to use x.x.x ranges
- Key charts: kube-state-metrics 5.1.1, metrics-server 7.4.13, node-exporter 4.5.20

This ensures Helm repository compatibility and proper dependency resolution.

🤖 Generated with [Claude Code](https://claude.ai/code)