### PR TITLE
feat(sonarqube): Add prepareBaseDir.enabled parameter to control init container

### DIFF
--- a/bitnami/sonarqube/Chart.yaml
+++ b/bitnami/sonarqube/Chart.yaml
@@ -37,5 +37,5 @@ maintainers:
 name: sonarqube
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/sonarqube
-version: 8.1.19
+version: 8.1.20
 # Trigger release for chart repository publishing

--- a/bitnami/sonarqube/templates/deployment.yaml
+++ b/bitnami/sonarqube/templates/deployment.yaml
@@ -64,6 +64,7 @@ spec:
       securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.podSecurityContext "context" $) | nindent 8 }}
       {{- end }}
       initContainers:
+        {{- if .Values.prepareBaseDir.enabled }}
         - name: prepare-base-dir
           image: {{ include "sonarqube.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
@@ -93,6 +94,7 @@ spec:
           volumeMounts:
             - name: empty-dir
               mountPath: /emptydir
+        {{- end }}
         {{- if .Values.plugins.install }}
         - name: {{ printf "%s-install-plugins-initcontainer" (include "common.names.fullname" .) }}
           image: {{ include "sonarqube.plugins.image" . }}

--- a/bitnami/sonarqube/values.yaml
+++ b/bitnami/sonarqube/values.yaml
@@ -459,6 +459,12 @@ extraVolumeMounts: []
 ##         containerPort: 1234
 ##
 sidecars: []
+## @param prepareBaseDir.enabled Enable/disable the prepare-base-dir init container
+## NOTE: When disabled, ensure your container image has proper directory structure
+## or handle directory preparation in your entrypoint script
+##
+prepareBaseDir:
+  enabled: true
 ## @param initContainers Add additional init containers to the SonarQube(TM) pod(s)
 ## ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
 ## e.g:


### PR DESCRIPTION
## Summary
Adds a new `prepareBaseDir.enabled` parameter to control whether the prepare-base-dir init container is created in SonarQube deployments.

## Problem
The prepare-base-dir init container is hardcoded in the chart template and cannot be disabled. This causes issues when using official SonarQube images instead of Bitnami images because:
- The init container expects `/opt/bitnami/sonarqube` path (doesn't exist in official images)
- It sources `/opt/bitnami/scripts/liblog.sh` (doesn't exist in official images)
- Official images have their files in `/opt/sonarqube` not `/opt/bitnami/sonarqube`

## Solution
- **New Parameter**: `prepareBaseDir.enabled` (default: `true` for backward compatibility)
- **Conditional Template**: Wrap prepare-base-dir init container in `{{- if .Values.prepareBaseDir.enabled }}`
- **Documentation**: Clear parameter documentation with usage notes
- **Version Bump**: Chart version 8.1.19 → 8.1.20

## Usage
```yaml
# Disable prepare-base-dir init container for official SonarQube images
prepareBaseDir:
  enabled: false
```

## Testing
- ✅ Maintains backward compatibility (default `enabled: true`)
- ✅ Template renders correctly with both `enabled: true` and `enabled: false`
- ✅ Addresses official SonarQube image compatibility issues

## Benefits
- Enables use of official SonarQube images without Bitnami dependencies
- Maintains full backward compatibility with existing deployments
- Provides flexibility for different SonarQube image types

🤖 Generated with [Claude Code](https://claude.ai/code)